### PR TITLE
Paas 743

### DIFF
--- a/src/main/java/org/jahia/modules/healthcheck/Constants.java
+++ b/src/main/java/org/jahia/modules/healthcheck/Constants.java
@@ -1,0 +1,53 @@
+/**
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2016 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * 2/ JSEL - Commercial and Supported Versions of the program
+ * ===================================================================================
+ *
+ * IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ * Alternatively, commercial and supported versions of the program - also known as Enterprise Distributions - must be
+ * used in accordance with the terms and conditions contained in a separate written agreement between you and Jahia
+ * Solutions Group SA.
+ *
+ * If you are unsure which license is appropriate for your use, please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.modules.healthcheck;
+
+public class Constants {
+
+    public static final String PROP_TOKENS = "tokens";
+    public static final String NODE_HEALTHCHECK_SETTINGS = "healthcheckSettings";
+
+    private Constants() {
+    }
+
+}

--- a/src/main/java/org/jahia/modules/healthcheck/HealthcheckConstants.java
+++ b/src/main/java/org/jahia/modules/healthcheck/HealthcheckConstants.java
@@ -42,12 +42,24 @@
  */
 package org.jahia.modules.healthcheck;
 
-public class Constants {
+import org.apache.jackrabbit.core.fs.FileSystem;
 
-    public static final String PROP_TOKENS = "tokens";
+public class HealthcheckConstants {
+
     public static final String NODE_HEALTHCHECK_SETTINGS = "healthcheckSettings";
+    public static final String NODE_SETTINGS = "settings";
+    public static final String NODE_TYPE_HEALTHCHECK_SETTINGS = "jnt:healthcheckSettings";
+    public static final String PARAM_TOKEN = "token";
+    public static final String PATH_SETTINGS = FileSystem.SEPARATOR + HealthcheckConstants.NODE_SETTINGS;
+    public static final String PATH_HEALTHCHECK_SETTINGS = PATH_SETTINGS + FileSystem.SEPARATOR + HealthcheckConstants.NODE_HEALTHCHECK_SETTINGS;
+    public static final String PROP_HEALTHCHECK_TOKEN = "healthcheck.token";
+    public static final String PROP_TOKENS = "tokens";
+    public static final String STATUS_GREEN = "GREEN";
+    public static final String STATUS_RED = "RED";
+    public static final String STATUS_YELLOW = "YELLOW";
+    
 
-    private Constants() {
+    private HealthcheckConstants() {
     }
 
 }

--- a/src/main/java/org/jahia/modules/healthcheck/HealthcheckConstants.java
+++ b/src/main/java/org/jahia/modules/healthcheck/HealthcheckConstants.java
@@ -57,7 +57,6 @@ public class HealthcheckConstants {
     public static final String STATUS_GREEN = "GREEN";
     public static final String STATUS_RED = "RED";
     public static final String STATUS_YELLOW = "YELLOW";
-    
 
     private HealthcheckConstants() {
     }

--- a/src/main/java/org/jahia/modules/healthcheck/actions/AddHealthcheckToken.java
+++ b/src/main/java/org/jahia/modules/healthcheck/actions/AddHealthcheckToken.java
@@ -5,7 +5,6 @@ import java.util.Locale;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang.RandomStringUtils;
-import org.apache.jackrabbit.core.fs.FileSystem;
 import org.jahia.api.Constants;
 import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;

--- a/src/main/java/org/jahia/modules/healthcheck/actions/AddHealthcheckToken.java
+++ b/src/main/java/org/jahia/modules/healthcheck/actions/AddHealthcheckToken.java
@@ -5,9 +5,11 @@ import java.util.Locale;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.jackrabbit.core.fs.FileSystem;
+import org.jahia.api.Constants;
 import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;
-import org.jahia.modules.healthcheck.Constants;
+import org.jahia.modules.healthcheck.HealthcheckConstants;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -29,18 +31,18 @@ public class AddHealthcheckToken extends Action {
         final boolean useNumbers = false;
         final String generatedString = RandomStringUtils.random(length, useLetters, useNumbers);
 
-        final JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentSystemSession("default", Locale.ENGLISH, Locale.ENGLISH);
+        final JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, Locale.ENGLISH, Locale.ENGLISH);
 
-        if (!session.nodeExists("/settings/" + Constants.NODE_HEALTHCHECK_SETTINGS)) {
-            session.getNode("/settings").addNode(Constants.NODE_HEALTHCHECK_SETTINGS, "jnt:healthcheckSettings");
+        if (!session.nodeExists(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS)) {
+            session.getNode(HealthcheckConstants.PATH_SETTINGS).addNode(HealthcheckConstants.NODE_HEALTHCHECK_SETTINGS, HealthcheckConstants.NODE_TYPE_HEALTHCHECK_SETTINGS);
             session.save();
         }
 
-        final JCRNodeWrapper healthcheckSettings = session.getNode("/settings/" + Constants.NODE_HEALTHCHECK_SETTINGS);
-        if (healthcheckSettings.hasProperty(Constants.PROP_TOKENS)) {
-            healthcheckSettings.getProperty(Constants.PROP_TOKENS).addValue(generatedString);
+        final JCRNodeWrapper healthcheckSettings = session.getNode(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS);
+        if (healthcheckSettings.hasProperty(HealthcheckConstants.PROP_TOKENS)) {
+            healthcheckSettings.getProperty(HealthcheckConstants.PROP_TOKENS).addValue(generatedString);
         } else {
-            healthcheckSettings.setProperty(Constants.PROP_TOKENS, new String[]{generatedString});
+            healthcheckSettings.setProperty(HealthcheckConstants.PROP_TOKENS, new String[]{generatedString});
         }
 
         session.save();

--- a/src/main/java/org/jahia/modules/healthcheck/actions/RemoveHealthcheckToken.java
+++ b/src/main/java/org/jahia/modules/healthcheck/actions/RemoveHealthcheckToken.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RemoveHealthcheckToken extends Action {
+
     private static final Logger logger = LoggerFactory.getLogger(RemoveHealthcheckToken.class);
 
     @Override
@@ -32,7 +33,7 @@ public class RemoveHealthcheckToken extends Action {
             return null;
         }
 
-        JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, Locale.ENGLISH,Locale.ENGLISH);
+        JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, Locale.ENGLISH, Locale.ENGLISH);
 
         if (!session.nodeExists(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS)) {
             session.getNode(HealthcheckConstants.PATH_SETTINGS).addNode(HealthcheckConstants.NODE_HEALTHCHECK_SETTINGS, HealthcheckConstants.NODE_TYPE_HEALTHCHECK_SETTINGS);
@@ -40,7 +41,7 @@ public class RemoveHealthcheckToken extends Action {
         }
 
         JCRValueWrapper[] values = session.getNode(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS).getProperty(HealthcheckConstants.PROP_TOKENS).getValues();
-        for (int i = 0 ; i < values.length; i++) {
+        for (int i = 0; i < values.length; i++) {
             if (values[i].getString().equals(token)) {
                 session.getNode(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS).getProperty(HealthcheckConstants.PROP_TOKENS).removeValue(values[i]);
             }

--- a/src/main/java/org/jahia/modules/healthcheck/actions/RemoveHealthcheckToken.java
+++ b/src/main/java/org/jahia/modules/healthcheck/actions/RemoveHealthcheckToken.java
@@ -15,6 +15,9 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.apache.jackrabbit.core.fs.FileSystem;
+import org.jahia.api.Constants;
+import org.jahia.modules.healthcheck.HealthcheckConstants;
 
 public class RemoveHealthcheckToken extends Action {
     private static final Logger logger = LoggerFactory.getLogger(RemoveHealthcheckToken.class);
@@ -25,23 +28,23 @@ public class RemoveHealthcheckToken extends Action {
         int length = 25;
         boolean useLetters = true;
         boolean useNumbers = false;
-        String token = httpServletRequest.getParameter("token");
+        String token = httpServletRequest.getParameter(HealthcheckConstants.PARAM_TOKEN);
 
         if (token == null) {
             return null;
         }
 
-        JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentSystemSession("default", new Locale("en"),new Locale("en"));
+        JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, Locale.ENGLISH,Locale.ENGLISH);
 
-        if (!session.nodeExists("/settings/healthcheckSettings")) {
-            session.getNode("/settings").addNode("healthcheckSettings", "jnt:healthcheckSettings");
+        if (!session.nodeExists(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS)) {
+            session.getNode(HealthcheckConstants.PATH_SETTINGS).addNode(HealthcheckConstants.NODE_HEALTHCHECK_SETTINGS, HealthcheckConstants.NODE_TYPE_HEALTHCHECK_SETTINGS);
             session.save();
         }
 
-        JCRValueWrapper[] values = session.getNode("/settings/healthcheckSettings").getProperty("tokens").getValues();
+        JCRValueWrapper[] values = session.getNode(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS).getProperty(HealthcheckConstants.PROP_TOKENS).getValues();
         for (int i = 0 ; i < values.length; i++) {
             if (values[i].getString().equals(token)) {
-                session.getNode("/settings/healthcheckSettings").getProperty("tokens").removeValue(values[i]);
+                session.getNode(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS).getProperty(HealthcheckConstants.PROP_TOKENS).removeValue(values[i]);
             }
         }
         session.save();

--- a/src/main/java/org/jahia/modules/healthcheck/actions/RemoveHealthcheckToken.java
+++ b/src/main/java/org/jahia/modules/healthcheck/actions/RemoveHealthcheckToken.java
@@ -1,7 +1,13 @@
 package org.jahia.modules.healthcheck.actions;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.jahia.api.Constants;
 import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;
+import org.jahia.modules.healthcheck.HealthcheckConstants;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.content.JCRValueWrapper;
@@ -10,14 +16,6 @@ import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import org.apache.jackrabbit.core.fs.FileSystem;
-import org.jahia.api.Constants;
-import org.jahia.modules.healthcheck.HealthcheckConstants;
 
 public class RemoveHealthcheckToken extends Action {
     private static final Logger logger = LoggerFactory.getLogger(RemoveHealthcheckToken.class);

--- a/src/main/java/org/jahia/modules/healthcheck/actions/RemoveHealthcheckToken.java
+++ b/src/main/java/org/jahia/modules/healthcheck/actions/RemoveHealthcheckToken.java
@@ -24,9 +24,6 @@ public class RemoveHealthcheckToken extends Action {
     @Override
     public ActionResult doExecute(HttpServletRequest httpServletRequest, RenderContext renderContext, Resource resource, JCRSessionWrapper jcrSessionWrapper, Map<String, List<String>> map, URLResolver urlResolver) throws Exception {
         logger.info("Removing healthcheck token.");
-        int length = 25;
-        boolean useLetters = true;
-        boolean useNumbers = false;
         String token = httpServletRequest.getParameter(HealthcheckConstants.PARAM_TOKEN);
 
         if (token == null) {

--- a/src/main/java/org/jahia/modules/healthcheck/interfaces/HealthcheckProbeService.java
+++ b/src/main/java/org/jahia/modules/healthcheck/interfaces/HealthcheckProbeService.java
@@ -29,23 +29,22 @@
  *     along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  *
- *     2/ JSEL - Commercial and Supported Versions of the program
- *     ===================================================================================
+ * 2/ JSEL - Commercial and Supported Versions of the program
+ * ===================================================================================
  *
- *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ * IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
  *
- *     Alternatively, commercial and supported versions of the program - also known as
- *     Enterprise Distributions - must be used in accordance with the terms and conditions
- *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ * Alternatively, commercial and supported versions of the program - also known as Enterprise Distributions - must be
+ * used in accordance with the terms and conditions contained in a separate written agreement between you and Jahia
+ * Solutions Group SA.
  *
- *     If you are unsure which license is appropriate for your use,
- *     please contact the sales department at sales@jahia.com.
+ * If you are unsure which license is appropriate for your use, please contact the sales department at sales@jahia.com.
  */
-
 package org.jahia.modules.healthcheck.interfaces;
 
 import java.util.List;
 
 public interface HealthcheckProbeService {
+
     public List<Probe> getProbes();
 }

--- a/src/main/java/org/jahia/modules/healthcheck/interfaces/Probe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/interfaces/Probe.java
@@ -44,10 +44,7 @@
 
 package org.jahia.modules.healthcheck.interfaces;
 
-import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.sql.SQLException;
 
 public interface Probe {
     String getStatus ();

--- a/src/main/java/org/jahia/modules/healthcheck/interfaces/Probe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/interfaces/Probe.java
@@ -29,25 +29,26 @@
  *     along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  *
- *     2/ JSEL - Commercial and Supported Versions of the program
- *     ===================================================================================
+ * 2/ JSEL - Commercial and Supported Versions of the program
+ * ===================================================================================
  *
- *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ * IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
  *
- *     Alternatively, commercial and supported versions of the program - also known as
- *     Enterprise Distributions - must be used in accordance with the terms and conditions
- *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ * Alternatively, commercial and supported versions of the program - also known as Enterprise Distributions - must be
+ * used in accordance with the terms and conditions contained in a separate written agreement between you and Jahia
+ * Solutions Group SA.
  *
- *     If you are unsure which license is appropriate for your use,
- *     please contact the sales department at sales@jahia.com.
+ * If you are unsure which license is appropriate for your use, please contact the sales department at sales@jahia.com.
  */
-
 package org.jahia.modules.healthcheck.interfaces;
 
 import org.json.JSONObject;
 
 public interface Probe {
-    String getStatus ();
-    JSONObject getData ();
+
+    String getStatus();
+
+    JSONObject getData();
+
     String getName();
 }

--- a/src/main/java/org/jahia/modules/healthcheck/probes/DBConnectivityProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/DBConnectivityProbe.java
@@ -44,6 +44,7 @@ package org.jahia.modules.healthcheck.probes;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import org.jahia.modules.healthcheck.HealthcheckConstants;
 import org.jahia.modules.healthcheck.interfaces.Probe;
 import org.jahia.utils.DatabaseUtils;
 import org.json.JSONObject;
@@ -57,13 +58,13 @@ public class DBConnectivityProbe implements Probe {
         try ( Connection conn = DatabaseUtils.getDatasource().getConnection()) {
             // The timeout value is defined in seconds.
             if (conn.isValid(20)) {
-                return "GREEN";
+                return HealthcheckConstants.STATUS_GREEN;
             } else {
-                return "RED";
+                return HealthcheckConstants.STATUS_RED;
             }
         } catch (SQLException e) {
             e.printStackTrace();
-            return "RED";
+            return HealthcheckConstants.STATUS_RED;
         }
 
     }

--- a/src/main/java/org/jahia/modules/healthcheck/probes/DBConnectivityProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/DBConnectivityProbe.java
@@ -49,9 +49,13 @@ import org.jahia.modules.healthcheck.interfaces.Probe;
 import org.jahia.utils.DatabaseUtils;
 import org.json.JSONObject;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component(service = Probe.class, immediate = true)
 public class DBConnectivityProbe implements Probe {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DBConnectivityProbe.class);
 
     @Override
     public String getStatus() {
@@ -62,8 +66,8 @@ public class DBConnectivityProbe implements Probe {
             } else {
                 return HealthcheckConstants.STATUS_RED;
             }
-        } catch (SQLException e) {
-            e.printStackTrace();
+        } catch (SQLException ex) {
+            LOGGER.debug("Impossible to check the validity of the DB connection", ex);
             return HealthcheckConstants.STATUS_RED;
         }
 

--- a/src/main/java/org/jahia/modules/healthcheck/probes/DBConnectivityProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/DBConnectivityProbe.java
@@ -29,19 +29,17 @@
  *     along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  *
- *     2/ JSEL - Commercial and Supported Versions of the program
- *     ===================================================================================
+ * 2/ JSEL - Commercial and Supported Versions of the program
+ * ===================================================================================
  *
- *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ * IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
  *
- *     Alternatively, commercial and supported versions of the program - also known as
- *     Enterprise Distributions - must be used in accordance with the terms and conditions
- *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ * Alternatively, commercial and supported versions of the program - also known as Enterprise Distributions - must be
+ * used in accordance with the terms and conditions contained in a separate written agreement between you and Jahia
+ * Solutions Group SA.
  *
- *     If you are unsure which license is appropriate for your use,
- *     please contact the sales department at sales@jahia.com.
+ * If you are unsure which license is appropriate for your use, please contact the sales department at sales@jahia.com.
  */
-
 package org.jahia.modules.healthcheck.probes;
 
 import java.sql.Connection;
@@ -54,10 +52,9 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = Probe.class, immediate = true)
 public class DBConnectivityProbe implements Probe {
 
-
     @Override
-    public String getStatus()  {
-        try (Connection conn = DatabaseUtils.getDatasource().getConnection()){
+    public String getStatus() {
+        try ( Connection conn = DatabaseUtils.getDatasource().getConnection()) {
             // The timeout value is defined in seconds.
             if (conn.isValid(20)) {
                 return "GREEN";

--- a/src/main/java/org/jahia/modules/healthcheck/probes/DBConnectivityProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/DBConnectivityProbe.java
@@ -44,14 +44,12 @@
 
 package org.jahia.modules.healthcheck.probes;
 
-import org.jahia.modules.healthcheck.interfaces.HealthcheckProbeService;
+import java.sql.Connection;
+import java.sql.SQLException;
 import org.jahia.modules.healthcheck.interfaces.Probe;
 import org.jahia.utils.DatabaseUtils;
 import org.json.JSONObject;
 import org.osgi.service.component.annotations.Component;
-
-import java.sql.Connection;
-import java.sql.SQLException;
 
 @Component(service = Probe.class, immediate = true)
 public class DBConnectivityProbe implements Probe {

--- a/src/main/java/org/jahia/modules/healthcheck/probes/DatastoreProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/DatastoreProbe.java
@@ -1,5 +1,7 @@
 package org.jahia.modules.healthcheck.probes;
 
+import java.io.File;
+import javax.jcr.RepositoryException;
 import org.apache.jackrabbit.core.SessionImpl;
 import org.apache.jackrabbit.core.persistence.PersistenceManager;
 import org.apache.jackrabbit.core.persistence.pool.BundleDbPersistenceManager;
@@ -15,9 +17,6 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.RepositoryException;
-import java.io.File;
-
 @Component(service = Probe.class, immediate = true)
 public class DatastoreProbe implements Probe {
 
@@ -25,7 +24,9 @@ public class DatastoreProbe implements Probe {
 
     @Override
     public String getStatus() {
-        if (isDbPersistenceManager()) return "GREEN";
+        if (isDbPersistenceManager()) {
+            return "GREEN";
+        }
         final String datastoreHome = System.getProperty("jahia.jackrabbit.datastore.path");
         return (new File(datastoreHome)).canWrite() ? "GREEN" : "RED";
     }

--- a/src/main/java/org/jahia/modules/healthcheck/probes/DatastoreProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/DatastoreProbe.java
@@ -8,6 +8,7 @@ import org.apache.jackrabbit.core.persistence.pool.BundleDbPersistenceManager;
 import org.apache.jackrabbit.core.version.InternalVersionManager;
 import org.apache.jackrabbit.core.version.InternalVersionManagerImpl;
 import org.apache.jackrabbit.core.version.InternalXAVersionManager;
+import org.jahia.modules.healthcheck.HealthcheckConstants;
 import org.jahia.modules.healthcheck.interfaces.Probe;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -25,10 +26,10 @@ public class DatastoreProbe implements Probe {
     @Override
     public String getStatus() {
         if (isDbPersistenceManager()) {
-            return "GREEN";
+            return HealthcheckConstants.STATUS_GREEN;
         }
         final String datastoreHome = System.getProperty("jahia.jackrabbit.datastore.path");
-        return (new File(datastoreHome)).canWrite() ? "GREEN" : "RED";
+        return (new File(datastoreHome)).canWrite() ? HealthcheckConstants.STATUS_GREEN : HealthcheckConstants.STATUS_RED;
     }
 
     @Override

--- a/src/main/java/org/jahia/modules/healthcheck/probes/RequestLoadProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/RequestLoadProbe.java
@@ -29,19 +29,17 @@
  *     along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  *
- *     2/ JSEL - Commercial and Supported Versions of the program
- *     ===================================================================================
+ * 2/ JSEL - Commercial and Supported Versions of the program
+ * ===================================================================================
  *
- *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ * IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
  *
- *     Alternatively, commercial and supported versions of the program - also known as
- *     Enterprise Distributions - must be used in accordance with the terms and conditions
- *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ * Alternatively, commercial and supported versions of the program - also known as Enterprise Distributions - must be
+ * used in accordance with the terms and conditions contained in a separate written agreement between you and Jahia
+ * Solutions Group SA.
  *
- *     If you are unsure which license is appropriate for your use,
- *     please contact the sales department at sales@jahia.com.
+ * If you are unsure which license is appropriate for your use, please contact the sales department at sales@jahia.com.
  */
-
 package org.jahia.modules.healthcheck.probes;
 
 import org.jahia.modules.healthcheck.interfaces.Probe;
@@ -79,7 +77,7 @@ public class RequestLoadProbe implements Probe {
         return "RED";
     }
 
-        @Override
+    @Override
     public JSONObject getData() {
         return loadAverageJson;
     }

--- a/src/main/java/org/jahia/modules/healthcheck/probes/RequestLoadProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/RequestLoadProbe.java
@@ -42,6 +42,7 @@
  */
 package org.jahia.modules.healthcheck.probes;
 
+import org.jahia.modules.healthcheck.HealthcheckConstants;
 import org.jahia.modules.healthcheck.interfaces.Probe;
 import org.jahia.utils.JCRSessionLoadAverage;
 import org.jahia.utils.RequestLoadAverage;
@@ -65,16 +66,16 @@ public class RequestLoadProbe implements Probe {
         }
         try {
             if (loadAverageJson.getInt("oneMinuteRequestLoadAverage") < 40 && loadAverageJson.getInt("oneMinuteCurrentSessionLoad") < 40) {
-                return "GREEN";
+                return HealthcheckConstants.STATUS_GREEN;
             }
             if (loadAverageJson.getInt("oneMinuteRequestLoadAverage") < 70 && loadAverageJson.getInt("oneMinuteCurrentSessionLoad") < 70) {
-                return "YELLOW";
+                return HealthcheckConstants.STATUS_YELLOW;
             }
 
         } catch (JSONException e) {
             e.printStackTrace();
         }
-        return "RED";
+        return HealthcheckConstants.STATUS_RED;
     }
 
     @Override

--- a/src/main/java/org/jahia/modules/healthcheck/probes/RequestLoadProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/RequestLoadProbe.java
@@ -49,9 +49,12 @@ import org.jahia.utils.RequestLoadAverage;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component(service = Probe.class, immediate = true)
 public class RequestLoadProbe implements Probe {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequestLoadProbe.class);
 
     JSONObject loadAverageJson = new JSONObject();
 
@@ -61,8 +64,8 @@ public class RequestLoadProbe implements Probe {
         try {
             loadAverageJson.put("oneMinuteRequestLoadAverage", RequestLoadAverage.getInstance().getOneMinuteLoad());
             loadAverageJson.put("oneMinuteCurrentSessionLoad", JCRSessionLoadAverage.getInstance().getOneMinuteLoad());
-        } catch (JSONException e) {
-            e.printStackTrace();
+        } catch (JSONException ex) {
+            LOGGER.error("Impossible to generate the JSON", ex);
         }
         try {
             if (loadAverageJson.getInt("oneMinuteRequestLoadAverage") < 40 && loadAverageJson.getInt("oneMinuteCurrentSessionLoad") < 40) {
@@ -72,8 +75,8 @@ public class RequestLoadProbe implements Probe {
                 return HealthcheckConstants.STATUS_YELLOW;
             }
 
-        } catch (JSONException e) {
-            e.printStackTrace();
+        } catch (JSONException ex) {
+            LOGGER.error("Impossible to read the JSON", ex);
         }
         return HealthcheckConstants.STATUS_RED;
     }

--- a/src/main/java/org/jahia/modules/healthcheck/services/HealthcheckProbeServiceImpl.java
+++ b/src/main/java/org/jahia/modules/healthcheck/services/HealthcheckProbeServiceImpl.java
@@ -1,68 +1,22 @@
-/**
- * ==========================================================================================
- * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
- * ==========================================================================================
- *
- *                                 http://www.jahia.com
- *
- *     Copyright (C) 2002-2018 Jahia Solutions Group SA. All rights reserved.
- *
- *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
- *     1/GPL OR 2/JSEL
- *
- *     1/ GPL
- *     ==================================================================================
- *
- *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
- *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- *
- *     2/ JSEL - Commercial and Supported Versions of the program
- *     ===================================================================================
- *
- *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
- *
- *     Alternatively, commercial and supported versions of the program - also known as
- *     Enterprise Distributions - must be used in accordance with the terms and conditions
- *     contained in a separate written agreement between you and Jahia Solutions Group SA.
- *
- *     If you are unsure which license is appropriate for your use,
- *     please contact the sales department at sales@jahia.com.
- */
+
 
 package org.jahia.modules.healthcheck.services;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.jahia.bin.Jahia;
 import org.jahia.exceptions.JahiaException;
 import org.jahia.exceptions.JahiaInitializationException;
 import org.jahia.modules.healthcheck.interfaces.HealthcheckProbeService;
-
-
 import org.jahia.modules.healthcheck.interfaces.Probe;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.framework.Constants;
-import org.jahia.bin.Jahia;
 import org.slf4j.Logger;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 
 @Component(name = "org.jahia.modules.healthcheck.service", service = HealthcheckProbeService.class, property = {
@@ -92,10 +46,11 @@ public class HealthcheckProbeServiceImpl implements HealthcheckProbeService {
 
     public void unregisterProbe(Probe probe) {
         final boolean success = probes.remove(probe);
-        if (success)
+        if (success) {
             logger.info(String.format("Unregistered %s in the Healthcheck Probe service", probe));
-        else
+        } else {
             logger.error(String.format("Failed to unregister %s in the contentIntegrity service", probe));
+        }
     }
 
     @Override

--- a/src/main/java/org/jahia/modules/healthcheck/services/HealthcheckProbeServiceImpl.java
+++ b/src/main/java/org/jahia/modules/healthcheck/services/HealthcheckProbeServiceImpl.java
@@ -1,5 +1,3 @@
-
-
 package org.jahia.modules.healthcheck.services;
 
 import java.util.ArrayList;
@@ -18,11 +16,10 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 
-
 @Component(name = "org.jahia.modules.healthcheck.service", service = HealthcheckProbeService.class, property = {
-        Constants.SERVICE_PID + "=org.jahia.modules.healthcheck.service",
-        Constants.SERVICE_DESCRIPTION + "=Healthcheck Probe Service",
-        Constants.SERVICE_VENDOR + "=" + Jahia.VENDOR_NAME}, immediate = true)
+    Constants.SERVICE_PID + "=org.jahia.modules.healthcheck.service",
+    Constants.SERVICE_DESCRIPTION + "=Healthcheck Probe Service",
+    Constants.SERVICE_VENDOR + "=" + Jahia.VENDOR_NAME}, immediate = true)
 public class HealthcheckProbeServiceImpl implements HealthcheckProbeService {
 
     private static Logger logger = org.slf4j.LoggerFactory.getLogger(HealthcheckProbeServiceImpl.class);

--- a/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
+++ b/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
@@ -1,50 +1,21 @@
-/**
- * ==========================================================================================
- * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
- * ==========================================================================================
- *
- *                                 http://www.jahia.com
- *
- *     Copyright (C) 2002-2018 Jahia Solutions Group SA. All rights reserved.
- *
- *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
- *     1/GPL OR 2/JSEL
- *
- *     1/ GPL
- *     ==================================================================================
- *
- *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
- *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- *
- *     2/ JSEL - Commercial and Supported Versions of the program
- *     ===================================================================================
- *
- *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
- *
- *     Alternatively, commercial and supported versions of the program - also known as
- *     Enterprise Distributions - must be used in accordance with the terms and conditions
- *     contained in a separate written agreement between you and Jahia Solutions Group SA.
- *
- *     If you are unsure which license is appropriate for your use,
- *     please contact the sales department at sales@jahia.com.
- */
+
 
 package org.jahia.modules.healthcheck.servlet;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Locale;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.jahia.api.Constants;
+import org.jahia.modules.healthcheck.HealthcheckConstants;
 import org.jahia.modules.healthcheck.interfaces.HealthcheckProbeService;
+import org.jahia.modules.healthcheck.interfaces.Probe;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -52,24 +23,8 @@ import org.jahia.settings.SettingsBean;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.osgi.service.http.HttpService;
-import org.jahia.modules.healthcheck.interfaces.Probe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-import javax.jcr.PathNotFoundException;
-import javax.jcr.RepositoryException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.List;
-import java.util.Locale;
-import org.apache.jackrabbit.core.fs.FileSystem;
-import org.jahia.api.Constants;
-import org.jahia.modules.healthcheck.HealthcheckConstants;
 
 
 /**
@@ -190,7 +145,9 @@ public class HealthcheckJSONProducer extends HttpServlet {
 
 
 
-        if(session.getUser().getUsername().equals("guest")) return false;
+        if(session.getUser().getUsername().equals("guest")) {
+            return false;
+        }
         try {
             return session.getNode("/sites/systemsite").hasPermission("healthcheck");
         } catch (PathNotFoundException ignored) {

--- a/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
+++ b/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
@@ -1,5 +1,3 @@
-
-
 package org.jahia.modules.healthcheck.servlet;
 
 import java.io.IOException;
@@ -26,10 +24,10 @@ import org.osgi.service.http.HttpService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  */
 public class HealthcheckJSONProducer extends HttpServlet {
+
     private Logger logger = LoggerFactory.getLogger(HealthcheckJSONProducer.class);
 
     private HttpService httpService;
@@ -111,7 +109,6 @@ public class HealthcheckJSONProducer extends HttpServlet {
                     result.put("duration", elapsedTime + " ms");
                     result.put("status", currentStatus);
 
-
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }
@@ -133,7 +130,7 @@ public class HealthcheckJSONProducer extends HttpServlet {
             if (token.equals(configurationToken)) {
                 return true;
             }
-            JCRSessionWrapper systemSession = JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, Locale.ENGLISH,Locale.ENGLISH);
+            JCRSessionWrapper systemSession = JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, Locale.ENGLISH, Locale.ENGLISH);
             if (systemSession.nodeExists(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS)) {
                 if (systemSession.getNode(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS).hasProperty(HealthcheckConstants.PROP_TOKENS)) {
                     if (systemSession.getNode(HealthcheckConstants.PATH_HEALTHCHECK_SETTINGS).getPropertyAsString(HealthcheckConstants.PROP_TOKENS).contains(token)) {
@@ -143,9 +140,7 @@ public class HealthcheckJSONProducer extends HttpServlet {
             }
         }
 
-
-
-        if(session.getUser().getUsername().equals("guest")) {
+        if (session.getUser().getUsername().equals("guest")) {
             return false;
         }
         try {

--- a/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
+++ b/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
@@ -20,7 +20,6 @@ import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.settings.SettingsBean;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.osgi.service.http.HttpService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HealthcheckJSONProducer extends HttpServlet {
 
-    private Logger logger = LoggerFactory.getLogger(HealthcheckJSONProducer.class);
+    private Logger LOGGER = LoggerFactory.getLogger(HealthcheckJSONProducer.class);
     public SettingsBean settingBean;
 
     public SettingsBean getSettingBean() {
@@ -83,14 +82,14 @@ public class HealthcheckJSONProducer extends HttpServlet {
                         System.out.println("JSONObject: " + healthcheckerJSON.toString());
                         JSONObject checkers;
                         if (!result.has("probes")) {
-                            logger.info("creating checkers");
+                            LOGGER.info("creating checkers");
                             checkers = new JSONObject();
                             result.put("probes", checkers);
                         } else {
                             checkers = result.getJSONObject("probes");
                         }
                         checkers.put(probes.get(i).getName(), healthcheckerJSON);
-                        logger.info("putting checkers " + probes.get(i).getName());
+                        LOGGER.info("putting checkers " + probes.get(i).getName());
 
                     }
                     result.put("registeredProbes", probes.size());
@@ -101,14 +100,14 @@ public class HealthcheckJSONProducer extends HttpServlet {
                     result.put("duration", elapsedTime + " ms");
                     result.put("status", currentStatus);
 
-                } catch (JSONException e) {
-                    e.printStackTrace();
+                } catch (JSONException ex) {
+                    LOGGER.error("Impossible to generate the JSON", ex);
                 }
             }
-        } catch (RepositoryException e) {
-            e.printStackTrace();
-        } catch (JSONException e) {
-            e.printStackTrace();
+        } catch (RepositoryException ex) {
+            LOGGER.error("Impossible to retrieve the JCR session", ex);
+        } catch (JSONException ex) {
+            LOGGER.error("Impossible to generate the JSON", ex);
         }
 
         writer.println(result.toString());
@@ -140,7 +139,7 @@ public class HealthcheckJSONProducer extends HttpServlet {
         } catch (PathNotFoundException ignored) {
             return false;
         } catch (RepositoryException e) {
-            logger.error("", e);
+            LOGGER.error("", e);
             return false;
         }
     }

--- a/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
+++ b/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
@@ -29,9 +29,6 @@ import org.slf4j.LoggerFactory;
 public class HealthcheckJSONProducer extends HttpServlet {
 
     private Logger logger = LoggerFactory.getLogger(HealthcheckJSONProducer.class);
-
-    private HttpService httpService;
-    private List<Probe> healthcheckers;
     public SettingsBean settingBean;
 
     public SettingsBean getSettingBean() {
@@ -51,13 +48,8 @@ public class HealthcheckJSONProducer extends HttpServlet {
     public void preDestroy() {
     }
 
-    public void setHttpService(HttpService httpService) {
-        this.httpService = httpService;
-    }
-
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String configurationToken = settingBean.getString(HealthcheckConstants.PROP_HEALTHCHECK_TOKEN, null);
         JSONObject result = new JSONObject();
         PrintWriter writer = resp.getWriter();
 

--- a/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
+++ b/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckJSONProducer.java
@@ -172,7 +172,7 @@ public class HealthcheckJSONProducer extends HttpServlet {
 
         if (token != null) {
             // checking if the token passed in jahia.property matches this one
-            if (configurationToken.equals(token)) {
+            if (token.equals(configurationToken)) {
                 return true;
             }
             JCRSessionWrapper systemSession = JCRSessionFactory.getInstance().getCurrentSystemSession("default", new Locale("en"),new Locale("en"));

--- a/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckServlet.java
+++ b/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckServlet.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 
 public class HealthcheckServlet implements BundleContextAware {
 
-    public static final Logger logger = LoggerFactory.getLogger(HealthcheckServlet.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(HealthcheckServlet.class);
 
     HealthcheckJSONProducer simpleServlet;
     BundleContext bundleContext;
@@ -71,11 +71,11 @@ public class HealthcheckServlet implements BundleContextAware {
         HttpService httpService = (HttpService) bundleContext.getService(realServiceReference);
         try {
             httpService.registerServlet("/healthcheck", simpleServlet, null, null);
-            logger.info("Successfully registered custom servlet at /modules/healthcheck");
-        } catch (ServletException e) {
-            e.printStackTrace();
-        } catch (NamespaceException e) {
-            e.printStackTrace();
+            LOGGER.info("Successfully registered custom servlet at /modules/healthcheck");
+        } catch (ServletException ex) {
+            LOGGER.error("Unsuccessfully registered custom servlet at /modules/healthcheck", ex);
+        } catch (NamespaceException ex) {
+            LOGGER.error("Unsuccessfully registered custom servlet at /modules/healthcheck", ex);
         }
 
     }
@@ -94,6 +94,6 @@ public class HealthcheckServlet implements BundleContextAware {
             return;
         }
         httpService.unregister("/healthcheck");
-        logger.info("Successfully unregistered custom servlet from /modules/healthcheck");
+        LOGGER.info("Successfully unregistered custom servlet from /modules/healthcheck");
     }
 }

--- a/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckServlet.java
+++ b/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckServlet.java
@@ -44,6 +44,7 @@
 
 package org.jahia.modules.healthcheck.servlet;
 
+import javax.servlet.ServletException;
 import org.eclipse.gemini.blueprint.context.BundleContextAware;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -51,8 +52,6 @@ import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.ServletException;
 
 
 public class HealthcheckServlet implements BundleContextAware {

--- a/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckServlet.java
+++ b/src/main/java/org/jahia/modules/healthcheck/servlet/HealthcheckServlet.java
@@ -29,19 +29,17 @@
  *     along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  *
- *     2/ JSEL - Commercial and Supported Versions of the program
- *     ===================================================================================
+ * 2/ JSEL - Commercial and Supported Versions of the program
+ * ===================================================================================
  *
- *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ * IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
  *
- *     Alternatively, commercial and supported versions of the program - also known as
- *     Enterprise Distributions - must be used in accordance with the terms and conditions
- *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ * Alternatively, commercial and supported versions of the program - also known as Enterprise Distributions - must be
+ * used in accordance with the terms and conditions contained in a separate written agreement between you and Jahia
+ * Solutions Group SA.
  *
- *     If you are unsure which license is appropriate for your use,
- *     please contact the sales department at sales@jahia.com.
+ * If you are unsure which license is appropriate for your use, please contact the sales department at sales@jahia.com.
  */
-
 package org.jahia.modules.healthcheck.servlet;
 
 import javax.servlet.ServletException;
@@ -52,7 +50,6 @@ import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 public class HealthcheckServlet implements BundleContextAware {
 


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-745

Short description: The first time we try to generate a token, an exception is being thrown because the property tokens does not exist for the node /settings/healthcheckSettings.
If we set an empty value for this property then it works but when we use the generated token, a NullPointException is being thrown because the property healthcheck.token does not exist.
These problems are now solved and I have also cleaned a little the code.
