### PR TITLE
PAAS-1387: check if Jahia Core has returned a null value for the request load

### DIFF
--- a/src/main/java/org/jahia/modules/healthcheck/probes/RequestLoadProbe.java
+++ b/src/main/java/org/jahia/modules/healthcheck/probes/RequestLoadProbe.java
@@ -104,6 +104,10 @@ public class RequestLoadProbe implements Probe {
                     requestLoadRedThresholdInt,
                     sessionLoadYellowThresholdInt,
                     sessionLoadRedThresholdInt);
+            if (!loadAverageJson.has("oneMinuteRequestLoadAverage") || !loadAverageJson.has("oneMinuteCurrentSessionLoad")) {
+                LOGGER.warn("Impossible to read request load values {} {}", loadAverageJson.has("oneMinuteRequestLoadAverage"), loadAverageJson.has("oneMinuteCurrentSessionLoad"));
+                return HealthcheckConstants.STATUS_YELLOW;
+            }
             if (loadAverageJson.getInt("oneMinuteRequestLoadAverage") < requestLoadYellowThresholdInt && loadAverageJson.getInt("oneMinuteCurrentSessionLoad") < sessionLoadYellowThresholdInt) {
                 return HealthcheckConstants.STATUS_GREEN;
             }


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1387

Short description: if the request load returned by Jahia Core is null, return a YELLOW state
